### PR TITLE
Preserve entropy in TokenGenerator

### DIFF
--- a/Util/TokenGenerator.php
+++ b/Util/TokenGenerator.php
@@ -37,7 +37,7 @@ class TokenGenerator implements TokenGeneratorInterface
 
     public function generateToken()
     {
-        return base_convert(bin2hex($this->getRandomNumber()), 16, 36);
+        return strtr(base64_encode($this->getRandomNumber()), '+/=', '.-~');
     }
 
     private function getRandomNumber()


### PR DESCRIPTION
base_convert loses precision on large inputs. Suggest using base64_encode instead, and replacing +/= characters with URL-safe equivalents.
